### PR TITLE
fix(workflow): use rebase merge instead of squash

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -25,4 +25,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # --auto waits for required status checks before merging
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
## Summary
Repository settings only allow rebase merges, but auto-merge workflow was using `--squash` flag causing all dependency PRs to fail with:
```
Squash merges are not allowed on this repository
```

## Changes
- Changed `gh pr merge --auto --squash` to `gh pr merge --auto --rebase`

## Impact
- 6 pending dependency PRs should auto-merge after this fix
- Future dependency PRs will merge correctly

## Test plan
- Merge this PR
- Verify pending dependency PRs auto-merge successfully