### PR TITLE
Fix CodeQL workflow branch triggers from master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '21 10 * * 5'
 


### PR DESCRIPTION
## Summary
- Updates branch references in CodeQL workflow to target the correct default branch 'main' instead of 'master'
- Fixes `codeql-analysis.yml`: Updates push and pull_request triggers to use main branch

## Test plan
- [x] Verified default branch is 'main' via `git branch -a`
- [ ] CodeQL workflow will trigger on pushes to main after merge
- [ ] CodeQL workflow will trigger on pull requests targeting main after merge