### PR TITLE
ci: fix CodeQL workflow branch triggers from master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '21 10 * * 5'
 


### PR DESCRIPTION
## Summary
- Fix CodeQL workflow triggers to use `main` instead of `master`
- The repository's default branch is `main` but the CodeQL workflow was configured to trigger on `master`

## Changes
- Updated `.github/workflows/codeql-analysis.yml` push and pull_request branch triggers from `master` to `main`

## Test plan
- [ ] CodeQL workflow should now trigger on pushes and PRs to main branch