### PR TITLE
Security: Pin action SHAs and add explicit permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '21 10 * * 5'
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 jobs:
   analyze:
     name: Analyze
@@ -35,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc # v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc # v4

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full commit SHAs (not tags) for enhanced security
- Add explicit permissions block to CodeQL workflow
- Maintain existing permissions in other workflows

## Changes
### docker-build-push.yml
- Pin actions/checkout@v6 to SHA `8e8c483db84b4bee98b60c0593521ed34d9990e8`
- Pin docker/setup-buildx-action@v3 to SHA `e468171a9de216ec08956ac3ada2f0791b6bd435`
- Pin docker/login-action@v3 to SHA `5e57cd118135c172c3672efd75eb46360885c0ef`
- Pin docker/metadata-action@v5 to SHA `c299e40c65443455700f0fdfc63efafe5b349051`
- Pin docker/build-push-action@v6 to SHA `263435318d21b8e681c14492fe198d362a7d2c83`
- Pin actions/attest-build-provenance@v3 to SHA `43d14bc2b83dec42d39ecae14e916627a18bb661`

### codeql-analysis.yml
- Pin actions/checkout@v6 to SHA `8e8c483db84b4bee98b60c0593521ed34d9990e8`
- Pin github/codeql-action/init@v4 to SHA `27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc`
- Pin github/codeql-action/autobuild@v4 to SHA `27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc`
- Pin github/codeql-action/analyze@v4 to SHA `27fcff4ecb39e96348e7ceddcc2d9ef42308b6fc`
- Add explicit permissions block (contents: read, security-events: write, actions: read)

### auto-merge-deps.yml
- No changes needed (already has explicit permissions block, no actions to pin)

## Security Benefits
1. **Immutable References**: Full SHA commits cannot be changed, preventing supply chain attacks
2. **Explicit Permissions**: Following principle of least privilege with minimal required permissions
3. **Audit Trail**: SHA comments preserve version information for maintainability

## Test Plan
- [ ] Verify workflows pass syntax validation
- [ ] Confirm Docker build workflow executes successfully
- [ ] Ensure CodeQL analysis completes without errors
- [ ] Check auto-merge workflow still functions for dependabot/renovate PRs