### PR TITLE
fix(login): adapt login request to timetracker v5 contract

### DIFF
--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -16,9 +16,12 @@ export const useUserStore = defineStore('user', {
     },
     async login(userdata) {
       const form = new FormData()
-      form.append('username', userdata.username)
-      form.append('password', userdata.password)
-      form.append('loginCookie', 'on')
+      form.append('_username', userdata.username)
+      form.append('_password', userdata.password)
+      // Stateless CSRF placeholder: the backend validates same-origin via the
+      // Sec-Fetch-Site header, which the /tt proxy forwards from the browser.
+      form.append('_csrf_token', 'csrf-token')
+      form.append('_remember_me', 'on')
 
       try {
         await request.post('login', form, {


### PR DESCRIPTION
## Problem

Login on stats.timetracker.nr fails with "Login failed - please check your credentials and try again" since the timetracker backend was upgraded from v4 to v5.

The v5 backend (Symfony 7.3) changed the login POST contract:

| | v4 | v5 |
|---|---|---|
| Username field | `username` | `_username` |
| Password field | `password` | `_password` |
| CSRF | none | `_csrf_token` mandatory (stateless same-origin) |
| Remember me | `loginCookie` | `_remember_me` |

With the old field names the backend rejects the request with *"Username and password cannot be empty"* before credentials are ever evaluated.

## Fix

Send the Symfony-standard field names, the stateless CSRF placeholder token, and `_remember_me`.

The placeholder value `csrf-token` is valid because the backend uses Symfony's `SameOriginCsrfTokenManager` (`stateless_token_ids: ['authenticate', 'logout']`): validation succeeds via the browser's `Sec-Fetch-Site: same-origin` header, which the `/tt` proxy (`srv/index.js`) forwards untouched. This mirrors what the backend's own login form renders for `csrf_token('authenticate')`.

## Verification

- Reproduced the failure and validated the new request format against the production v5 backend (dummy credentials reach the LDAP lookup instead of failing on field parsing / CSRF).
- Hot-patched the running stats.timetracker.nr container with this exact change; real login confirmed working.
- `pnpm exec eslint src/stores/user.js` and `pnpm build` pass.
