### PR TITLE
chore: release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timetracker-ui",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "Timetracker UI",
   "author": "Christian Opitz <christian.opitz@netresearch.de>",
   "private": true,


### PR DESCRIPTION
Bump version to 3.0.0.

Major release: the login request now follows the timetracker v5 contract (`_username`/`_password`/`_csrf_token`/`_remember_me`, #745). **Breaking**: this UI version requires a timetracker v5 backend; it no longer works against v4.