### PR TITLE
docs: simplify deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,8 @@
 > [!WARNING]
 > **This repository is deprecated and archived.**
 >
-> The statistics feature this app provided (formerly hosted at `stats.timetracker.nr`)
-> is now **part of [timetracker](https://github.com/netresearch/timetracker) itself**.
-> The standalone service has been decommissioned and `stats.timetracker.nr` now
-> redirects to the main timetracker application.
->
-> No further development or releases will happen here. See NRS-4501 for the
-> decommissioning details.
+> Its functionality is now part of [timetracker](https://github.com/netresearch/timetracker)
+> itself. No further development or releases will happen here.
 
 A modern user interface for [timetracker](https://github.com/netresearch/timetracker) - serving statistics and analytics.
 


### PR DESCRIPTION
Removes internal references from the public deprecation notice; keeps a generic pointer to timetracker.